### PR TITLE
remove use of static result variable

### DIFF
--- a/PolyUtil.php
+++ b/PolyUtil.php
@@ -373,8 +373,8 @@ class PolyUtil {
             $dLat = $lat - $lastLat;
             $dLng = $lng - $lastLng;
 
-            self::enc($dLat, $result);
-            self::enc($dLng, $result);
+            $result.=self::enc($dLat);
+            $result.=self::enc($dLng);
 
             $lastLat = $lat;
             $lastLng = $lng;
@@ -384,10 +384,12 @@ class PolyUtil {
     
     
     
-    private static function enc($v, $result) {
+    private static function enc($v) {
 
         $v = $v < 0 ? ~($v << 1) : $v << 1;
 
+        $result = '';
+        
         while ($v >= 0x20) {
             $result.= chr((int) ((0x20 | ($v & 0x1f)) + 63));
             $v >>= 5;
@@ -395,6 +397,7 @@ class PolyUtil {
         
         $result.=chr((int) ($v + 63));
         
+        return $result;
     }    
     
 }

--- a/PolyUtil.php
+++ b/PolyUtil.php
@@ -23,10 +23,7 @@ use GeometryLibrary\SphericalUtil;
 
 class PolyUtil {
     
-    const DEFAULT_TOLERANCE = 0.1;  // meters.  
-    
-    private static $result = '';
-
+    const DEFAULT_TOLERANCE = 0.1;  // meters.
 
     /**
      * Returns tan(latitude-at-lng3) on the great circle (lat1, lng1) to (lat2, lng2). lng1==0.
@@ -376,27 +373,27 @@ class PolyUtil {
             $dLat = $lat - $lastLat;
             $dLng = $lng - $lastLng;
 
-            self::enc($dLat);
-            self::enc($dLng);
+            self::enc($dLat, $result);
+            self::enc($dLng, $result);
 
             $lastLat = $lat;
             $lastLng = $lng;
         }
-        return self::$result;
+        return $result;
     }    
     
     
     
-    private static function enc($v) {
+    private static function enc($v, $result) {
 
         $v = $v < 0 ? ~($v << 1) : $v << 1;
 
         while ($v >= 0x20) {
-            self::$result.= chr((int) ((0x20 | ($v & 0x1f)) + 63));
+            $result.= chr((int) ((0x20 | ($v & 0x1f)) + 63));
             $v >>= 5;
         }
         
-        self::$result.=chr((int) ($v + 63));
+        $result.=chr((int) ($v + 63));
         
     }    
     


### PR DESCRIPTION
old implementation had logical error when using class more than once for encoding.