### PR TITLE
Add PHP 7.4 compatability

### DIFF
--- a/PolyUtil.php
+++ b/PolyUtil.php
@@ -333,7 +333,7 @@ class PolyUtil {
             $shift = 0;
             $b;
             do {
-                $b = ord($encodedPath{$index++}) - 63 - 1;
+                $b = ord($encodedPath[$index++]) - 63 - 1;
                 $result += $b << $shift;
                 $shift += 5;
             } while ($b >= hexdec("0x1f"));
@@ -343,7 +343,7 @@ class PolyUtil {
             $result = 1;
             $shift = 0;
             do {
-                $b = ord($encodedPath{$index++}) - 63 - 1;
+                $b = ord($encodedPath[$index++]) - 63 - 1;
                 $result += $b << $shift;
                 $shift += 5;
             } while ($b >= hexdec("0x1f"));

--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,31 @@
 {
 	"name": "alexpechkarev/geometry-library",
 	"description": "PHP Geometry library provides utility functions for the computation of geometric data on the surface of the Earth.",
-        "version":"1.0.1",
-	"keywords": ["google maps geometry library", "php geometry library", "spherical geometry utilities", "encoding and decoding polyline paths utilities", "computations polygons and polylines"],
-        "homepage":"https://alexpechkarev.github.io/geometry-library/",
+	"version": "1.0.2",
+	"keywords": [
+		"google maps geometry library",
+		"php geometry library",
+		"spherical geometry utilities",
+		"encoding and decoding polyline paths utilities",
+		"computations polygons and polylines"
+	],
+	"homepage": "https://alexpechkarev.github.io/geometry-library/",
 	"license": "MIT",
-        "authors": [
-            {
-                "name": "Alexander Pechkarev",
-                "email": "alexpechkarev@gmail.com"
-            }
-        ],    
-        "minimum-stability": "stable",
-        
+	"authors": [
+		{
+			"name": "Alexander Pechkarev",
+			"email": "alexpechkarev@gmail.com"
+		}
+	],
+	"minimum-stability": "stable",
 	"autoload": {
 		"psr-4": {
 			"GeometryLibrary\\": "/"
 		}
-	},        
-        
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0-dev"
-        }
-    }
-    
-	
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "1.0-dev"
+		}
+	}
 }


### PR DESCRIPTION
In PHP 7.4 the curly braces give the following error: `Array and string offset access syntax with curly braces is deprecated`

Using square brackets fixes this.
